### PR TITLE
Added Password View option for both login and signup page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tailwindcss/vite": "^4.1.11",
         "appwrite": "^18.1.1",
+        "lucide-react": "^0.544.0",
         "node-appwrite": "^17.1.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -3300,6 +3301,14 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.544.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.544.0.tgz",
+      "integrity": "sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.1.11",
     "appwrite": "^18.1.1",
+    "lucide-react": "^0.544.0",
     "node-appwrite": "^17.1.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -2,6 +2,8 @@ import { useState, useEffect } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import { forceLogout } from '../utils/sessionUtils';
+import { Eye, EyeOff } from 'lucide-react'; 
+
 const Login = () => {
     const { login, user } = useAuth();
     const navigate = useNavigate();
@@ -9,6 +11,7 @@ const Login = () => {
     const [error, setError] = useState('');
     const [isOnline, setIsOnline] = useState(navigator.onLine);
     const [showSessionConflict, setShowSessionConflict] = useState(false);
+    const [showPassword, setShowPassword] = useState(false);
     const [formData, setFormData] = useState({
         email: '',
         password: ''
@@ -135,16 +138,25 @@ const Login = () => {
                                 <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-2">
                                     Password
                                 </label>
-                                <input
-                                    type="password"
-                                    name="password"
-                                    id="password"
-                                    value={formData.password}
-                                    onChange={handleInputChange}
-                                    placeholder="Enter your password"
-                                    required
-                                    className="w-full px-4 py-3 text-lg bg-white/70 backdrop-blur-sm border border-white/30 rounded-2xl focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 transition-all duration-200 placeholder-gray-400 shadow-lg"
-                                />
+                                <div className="relative">
+                                    <input
+                                        type={showPassword ? "text" : "password"} // toggle type
+                                        name="password"
+                                        id="password"
+                                        value={formData.password}
+                                        onChange={handleInputChange}
+                                        placeholder="Enter your password"
+                                        required
+                                        className="w-full px-4 py-3 pr-12 text-lg bg-white/70 backdrop-blur-sm border border-white/30 rounded-2xl focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 transition-all duration-200 placeholder-gray-400 shadow-lg"
+                                    />
+                                    <button
+                                        type="button"
+                                        onClick={() => setShowPassword(!showPassword)}
+                                        className="absolute inset-y-0 right-3 flex items-center text-gray-500 hover:text-gray-700"
+                                    >
+                                        {showPassword ? <EyeOff size={20} /> : <Eye size={20} />}
+                                    </button>
+                                </div>
                             </div>
                         </div>
                         <button 

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -2,12 +2,16 @@ import { useState, useEffect } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import { validatePassword } from '../utils/validation';
+import { Eye, EyeOff } from 'lucide-react'; 
+
 import PasswordStrength from '../components/PasswordStrength';
 const Signup = () => {
     const { signup, user } = useAuth();
     const navigate = useNavigate();
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState('');
+    const [showPassword1, setShowPassword1] = useState(false);
+    const [showPassword2, setShowPassword2] = useState(false);
     const [formData, setFormData] = useState({
         name: '',
         email: '',
@@ -118,8 +122,9 @@ const Signup = () => {
                                 <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-2">
                                     Password
                                 </label>
+                                <div className='relative'>
                                 <input
-                                    type="password"
+                                     type={showPassword1 ? "text" : "password"}
                                     name="password"
                                     id="password"
                                     value={formData.password}
@@ -128,6 +133,14 @@ const Signup = () => {
                                     required
                                     className="w-full px-4 py-3 text-lg bg-white/70 backdrop-blur-sm border border-white/30 rounded-2xl focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 transition-all duration-200 placeholder-gray-400 shadow-lg"
                                 />
+                                <button
+                                        type="button"
+                                        onClick={() => setShowPassword1(!showPassword1)}
+                                        className="absolute inset-y-0 right-3 flex items-center text-gray-500 hover:text-gray-700"
+                                    >
+                                        {showPassword1 ? <EyeOff size={20} /> : <Eye size={20} />}
+                                    </button>
+                                </div>
                                 {formData.password && (
                                     <div className="mt-2">
                                         <PasswordStrength password={formData.password} />
@@ -138,8 +151,9 @@ const Signup = () => {
                                 <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-700 mb-2">
                                     Confirm Password
                                 </label>
+                                <div className='relative'>
                                 <input
-                                    type="password"
+                                     type={showPassword2 ? "text" : "password"}
                                     name="confirmPassword"
                                     id="confirmPassword"
                                     value={formData.confirmPassword}
@@ -148,6 +162,14 @@ const Signup = () => {
                                     required
                                     className="w-full px-4 py-3 text-lg bg-white/70 backdrop-blur-sm border border-white/30 rounded-2xl focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 transition-all duration-200 placeholder-gray-400 shadow-lg"
                                 />
+                                <button
+                                        type="button"
+                                        onClick={() => setShowPassword2(!showPassword2)}
+                                        className="absolute inset-y-0 right-3 flex items-center text-gray-500 hover:text-gray-700"
+                                    >
+                                        {showPassword2 ? <EyeOff size={20} /> : <Eye size={20} />}
+                                    </button>
+                                </div>
                             </div>
                         </div>
                         <button 


### PR DESCRIPTION
Added Password View option for both login and signup page using lucide-react
 
<img width="500" height="700" alt="image" src="https://github.com/user-attachments/assets/1f729554-eed2-4d5f-97ac-2186bfbf7669" />
<img width="500" height="700" alt="image" src="https://github.com/user-attachments/assets/c3a76e93-294b-4812-b4cc-720026d6595e" />
<img width="500" height="700" alt="image" src="https://github.com/user-attachments/assets/05a7d9ba-6b17-4fa3-8e51-1b3df10c5fb4" />


Closes issue #10 