### PR TITLE
Fix: delete account flow 

### DIFF
--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { Link } from 'react-router-dom';
 const Settings = () => {
-    const { user, userProfile, updateProfile, logout } = useAuth();
+    const { user, userProfile, updateProfile, logout, deleteAccount } = useAuth();
     const [activeTab, setActiveTab] = useState('profile');
     const [isLoading, setIsLoading] = useState(false);
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -208,7 +208,6 @@ const Settings = () => {
                     {activeTab === 'account' && (
                         <div className="space-y-6">
                             <h2 className="text-2xl font-bold text-[hsl(var(--card-foreground))] mb-6">Account Settings</h2>
-                                <h2 className="text-2xl font-bold text-[hsl(var(--card-foreground))] mb-6">Account Settings</h2>
                             <div className="space-y-4">
                                     <div className="bg-[hsl(var(--card))]/50 backdrop-blur-sm rounded-xl p-4 border border-[hsl(var(--border))]">
                                         <h3 className="font-semibold text-[hsl(var(--card-foreground))] mb-2">Account Information</h3>
@@ -251,8 +250,16 @@ const Settings = () => {
                                 Cancel
                             </button>
                             <button
-                                onClick={() => {
+                                onClick={async () => {
                                     setShowDeleteConfirm(false);
+                                    setIsLoading(true);
+                                    try {
+                                        await deleteAccount();
+                                    } catch (e) {
+                                        alert('Failed to delete account. Please try again.');
+                                    } finally {
+                                        setIsLoading(false);
+                                    }
                                 }}
                                 className="flex-1 px-4 py-2 bg-[hsl(var(--destructive))] text-[hsl(var(--destructive-foreground))] rounded-lg hover:brightness-95"
                             >

--- a/src/services/userRecipeService.js
+++ b/src/services/userRecipeService.js
@@ -272,6 +272,26 @@ class UserRecipeService {
     }
   }
 
+  async clearFavorites(userId) {
+    try {
+      const response = await databases.listDocuments(
+        this.databaseId,
+        this.favoritesCollectionId,
+        [Query.equal('userId', userId)]
+      );
+
+      const deletePromises = response.documents.map(doc =>
+        databases.deleteDocument(this.databaseId, this.favoritesCollectionId, doc.$id)
+      );
+
+      await Promise.all(deletePromises);
+      console.log('🗑️ All favorites cleared from database');
+    } catch (error) {
+      console.error('Error clearing favorites from database:', error);
+      throw error;
+    }
+  }
+
   // Helper methods
   extractIngredientsText(recipe) {
     if (recipe.ingredients && Array.isArray(recipe.ingredients)) {


### PR DESCRIPTION
Fixes: #89 
_ Summary_

This PR implements a functional Delete Account flow 
The Delete Account button is now fully wired to the authentication context and performs all necessary cleanup actions before redirecting the user.

_Changes_
**src/pages/Settings.jsx**

Imported deleteAccount from useAuth.

Integrated the Delete Account button to call deleteAccount() upon confirmation in the delete modal.

Removed the duplicate <h2>Account Settings</h2> heading.

**src/contexts/AuthContext.jsx**

Added a new deleteAccount() method that:

Clears meal logs and favorites.

Deletes the user profile.

Ends user sessions and resets state.

Redirects the user to /.

Exposed deleteAccount through the context for usage across the app.

**src/services/userRecipeService.js**

Added a new helper method clearFavorites(userId) to bulk-delete all user favorites.

_Test Plan_

Log in and navigate to Settings → Account.

Verify that there is only one “Account Settings” heading.

Click Delete Account → Confirm.

Confirm that:

All user data (logs and favorites) is removed.

The session ends.

The user is redirected to the home page (/).

